### PR TITLE
Coveralls for non-Travis CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,5 +34,5 @@ jobs:
           command: CI_REPORTS=spec/reports RAILS_ENV=test COVERAGE=true bundle exec rake ci:setup:rspec spec
       - run:
           name: Send reports to testspace
-          command: testspace @.testspace.txt
+          command: testspace @.testspace.txt --link=coveralls
           when: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
       - name: Test
         env:
           CI_NAME: github
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export CI_BUILD_NUMBER=${GITHUB_RUN_NUMBER}
-          export CI_JOB_ID=${GITHUB_JOB}
+          export CI_JOB_ID=${GITHUB_RUN_ID}
           export CI_BUILD_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           export CI_BRANCH=${GITHUB_REF#refs/heads/}
           #export CI_PULL_REQUEST=`jq -r .number "${GITHUB_EVENT_PATH}"`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,12 @@ jobs:
       - name: Test
         env:
           CI_NAME: github
-          CI_BUILD_NUMBER: ${{ env.GITHUB_RUN_NUMBER }}
-          CI_JOB_ID: ${{ env.GITHUB_RUN_ID }}
-          CI_BUILD_URL: "${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}"
-          CI_BRANCH: ${{ env.GITHUB_REF }}
-          #CI_PULL_REQUEST: ${{ env.GITHUB_RUN_ID }}
         run: |
+          export CI_BUILD_NUMBER=${GITHUB_RUN_NUMBER}
+          export CI_JOB_ID=${GITHUB_RUN_ID}
+          export CI_BUILD_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          export CI_BRANCH=${GITHUB_REF#refs/heads/}
+          #export CI_PULL_REQUEST=`jq -r .number "${GITHUB_EVENT_PATH}"`
           CI_REPORTS=spec/reports RAILS_ENV=test COVERAGE=true xvfb-run --server-args="-screen 0 1024x768x24" bundle exec rake ci:setup:rspec spec
       - name: Push
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           CI_NAME: github
         run: |
           export CI_BUILD_NUMBER=${GITHUB_RUN_NUMBER}
-          export CI_JOB_ID=${GITHUB_RUN_ID}
+          export CI_JOB_ID=${GITHUB_JOB}
           export CI_BUILD_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           export CI_BRANCH=${GITHUB_REF#refs/heads/}
           #export CI_PULL_REQUEST=`jq -r .number "${GITHUB_EVENT_PATH}"`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,16 @@ jobs:
           bundle exec brakeman -o tmp/brakeman.json
           bundle exec brakeman_translate_checkstyle_format translate --file="tmp/brakeman.json" > tmp/brakeman_checkstyle.xml
       - name: Test
+        env:
+          CI_NAME: github
+          CI_BUILD_NUMBER: ${{ env.GITHUB_RUN_NUMBER }}
+          CI_JOB_ID: ${{ env.GITHUB_RUN_ID }}
+          CI_BUILD_URL: "${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}"
+          CI_BRANCH: ${{ env.GITHUB_REF }}
+          #CI_PULL_REQUEST: ${{ env.GITHUB_RUN_ID }}
         run: |
           CI_REPORTS=spec/reports RAILS_ENV=test COVERAGE=true xvfb-run --server-args="-screen 0 1024x768x24" bundle exec rake ci:setup:rspec spec
       - name: Push
         run: |
-          testspace @.testspace.txt
+          testspace @.testspace.txt --link=coveralls
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Test
         env:
           CI_NAME: github
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
           export CI_BUILD_NUMBER=${GITHUB_RUN_NUMBER}
           export CI_JOB_ID=${GITHUB_JOB}


### PR DESCRIPTION
Coveralls and Travis has a built-in integration that requires no special settings!

For any non-Travis CI, to be able to push to Coveralls, it is required to have `COVERALLS_REPO_TOKEN` secret - see https://docs.coveralls.io/ruby-on-rails#configuration

Circle CI context is auto recognized by Coveralls so there is no need to configure anything else.


For GitHub Actions, as it is unknown to Coveralls, it is required to [explicitly set several env-vars](https://github.com/lemurheavy/coveralls-ruby/blob/master/lib/coveralls/configuration.rb#L116-L123):
```
CI_NAME
CI_BUILD_NUMBER
CI_JOB_ID
CI_BUILD_URL
CI_BRANCH
CI_PULL_REQUEST
```
Also, the `COVERALLS_REPO_TOKEN` is not taken from Coveralls as mentioned above but the GitHub's `GITHUB_TOKEN` secret must be used.
